### PR TITLE
Update to latest nixpkgs-unstable and remove `tunnelvr` specifics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# nix-godot-android
+
+A nix flake that wrap Godot with the Android runtime and Gradle (VR ready).
+
+## usage
+
+Create a file `flake.nix` at the root of your project, you can then enter the development environment using `nix develop`.
+
+```
+{
+  description = "Example usage of nix-godot-android";
+  inputs.nix-godot-android.url = "github:jahkosha/nix-godot-android";
+  inputs.nixpkgs.url = "nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs, nix-godot-android }: {
+    devShells.x86_64-linux.default = nix-godot-android.devShells.x86_64-linux.default;
+  };
+}
+```

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1729369131,
-        "narHash": "sha256-PtfScp+nQd1PsT5rf0Qgjdbsh4Iag6R1ivYMWLizyIc=",
+        "lastModified": 1747772512,
+        "narHash": "sha256-xtVjWNMiH8Y2chm63CUuIQaOj65qUGiyKjpdMXquYDM=",
         "owner": "tadfisher",
         "repo": "android-nixpkgs",
-        "rev": "82bffbf3f06bdccf44fc62a9bd4f152ac80a55b0",
+        "rev": "10111372b778ea2a89dbe951f5b6db51df773cfc",
         "type": "github"
       },
       "original": {
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728330715,
-        "narHash": "sha256-xRJ2nPOXb//u1jaBnDP56M7v5ldavjbtR6lfGqSvcKg=",
+        "lastModified": 1741473158,
+        "narHash": "sha256-kWNaq6wQUbUMlPgw8Y+9/9wP0F8SHkjy24/mN3UAppg=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "dd6b80932022cea34a019e2bb32f6fa9e494dfef",
+        "rev": "7c9e793ebe66bcba8292989a68c0419b737a22a0",
         "type": "github"
       },
       "original": {
@@ -46,11 +46,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -61,11 +61,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1729256560,
-        "narHash": "sha256-/uilDXvCIEs3C9l73JTACm4quuHUsIHcns1c+cHUJwA=",
+        "lastModified": 1747542820,
+        "narHash": "sha256-GaOZntlJ6gPPbbkTLjbd8BMWaDYafhuuYRNrxCGnPJw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4c2fcb090b1f3e5b47eaa7bd33913b574a11e0a0",
+        "rev": "292fa7d4f6519c074f0a50394dbbe69859bb6043",
         "type": "github"
       },
       "original": {
@@ -77,11 +77,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1729256560,
-        "narHash": "sha256-/uilDXvCIEs3C9l73JTACm4quuHUsIHcns1c+cHUJwA=",
+        "lastModified": 1747744144,
+        "narHash": "sha256-W7lqHp0qZiENCDwUZ5EX/lNhxjMdNapFnbErcbnP11Q=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4c2fcb090b1f3e5b47eaa7bd33913b574a11e0a0",
+        "rev": "2795c506fe8fb7b03c36ccb51f75b6df0ab2553f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This remove the `tunnelvr` specifcs (but I understand if you prefer to keep them in your repository, in that case I can split the changes) and update to the latest nixpkgs-unstable (not so interesting, but they introduced a godot_4_4, which means we don't have to inherit from godot 4.3 anymore).